### PR TITLE
small fixes

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -51,4 +51,5 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y \
 
 ENV LC_ALL="en_US.UTF-8"
 ENV LC_CTYPE="en_US.UTF-8"
+ENV EDITOR="code --wait"
 RUN dpkg-reconfigure locales

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -9,7 +9,7 @@
 		// Preserve bash history
 		"source=therepo-bashhistory,target=/commandhistory,type=volume",
 		// Preserve Github CLI storage
-		"source=therepo-github-cli,target=/root/.config/gh,type=volume",
+		"source=therepo-dot-config,target=/root/.config,type=volume",
 		// Preserve kubectl
 		"source=therepo-kubectl,target=/root/.kube,type=volume"
 	],


### PR DESCRIPTION
small fixes
- move all /root/.config into its own docker volume
- add EDITOR variable to support VSCode as default editor

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/khumps/monorepo/pull/4).
* __->__ #4
