### PR TITLE
fix transmission rollout strategy

### DIFF
--- a/terraform/knowhere.tf
+++ b/terraform/knowhere.tf
@@ -574,6 +574,9 @@ resource "kubernetes_deployment" "knowhere_transmission" {
   spec {
 
     replicas = 1
+    strategy {
+      type = "Recreate"
+    }
     selector {
       match_labels = {
         app : local.transmission-name


### PR DESCRIPTION
fix transmission rollout strategy
Transmission pod was defaulting to rolling deploys which isn't possible because the pod relies on the NFS mount which can't be shared. Changed rollout strategy to recreate so it deletes the pod before starting the new one. This probably should be a stateful set to ensure that only one pod with the specific state exists.

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/khumps/monorepo/pull/24).
* __->__ #24
